### PR TITLE
Replace `fmt.Fprintln` with `fmt.Fprintf`

### DIFF
--- a/chapters/04.md
+++ b/chapters/04.md
@@ -32,7 +32,7 @@ func _main() error {
 
 func main() {
   if err := _main(); err != nil {
-    fmt.Fprintln(os.Stderr, "X %s", err.Error())
+    fmt.Fprintf(os.Stderr, "X %s\n", err.Error())
   }
 }
 ```


### PR DESCRIPTION
Thanks for the great tutorial @vilmibm. ❤️

As a tiny contribution, this PR fixes the wrong usage of `fmt.Fprintln` (i.e., it doesn't support formatting), by replacing it with `fmt.Fprintf`.